### PR TITLE
Update libssh2 to fix CVE-2026-55200

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libssh2-sys/libssh2"]
 	path = libssh2-sys/libssh2
-	url = https://github.com/libssh2/libssh2
+	url = https://github.com/Manishearth/libssh2
 	branch = master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh2"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>", "Matteo Bigoi <bigo@crisidev.org>"]
 license = "MIT OR Apache-2.0"
 keywords = ["ssh"]
@@ -20,7 +20,7 @@ openssl-on-win32 = ["libssh2-sys/openssl-on-win32"]
 [dependencies]
 bitflags = "2"
 libc = "0.2"
-libssh2-sys = { path = "libssh2-sys", version = "0.3.1" }
+libssh2-sys = { path = "libssh2-sys", version = "0.3.2" }
 parking_lot = "0.12"
 
 [dev-dependencies]

--- a/libssh2-sys/Cargo.toml
+++ b/libssh2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libssh2-sys"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Wez Furlong <wez@wezfurlong.org>", "Matteo Bigoi <bigo@crisidev.org>"]
 links = "ssh2"
 build = "build.rs"


### PR DESCRIPTION
This PR updates the `libssh2` submodule to a backported version of `1.11.1` that addresses multiple recent security vulnerabilities and includes a critical follow-up bugfix:

### Patched Vulnerabilities:
1.  **CVE-2026-55200** (Critical): Heap-based buffer overflow in `ssh2_transport_read()` due to missing bounds check on `packet_length` in the `chacha20-poly1305` path.
    *   *Backported from upstream commit*: `97acf3dfda80c91c3a8c9f2372546301d4a1a7a8`
2.  **CVE-2026-55199** (High): Pre-authentication infinite loop in `EXT_INFO` handler in `packet.c` due to unchecked return value of `_libssh2_get_string()`.
    *   *Backported from upstream commit*: `17626857d20b3c9a1addfa45979dadcee1cd84a4`
3.  **CVE-2025-15661** (Medium): Out-of-bounds read in SFTP symlink code in `sftp.c`.
    *   *Backported from upstream commit*: `2dae3024897e1898d389835151f4e9606227721d`

### Additional Fixes:
*   **SFTP Symlink Bugfix**: Moves advancing past packet ID before reading the `FXP_STATUS` response in `sftp_symlink`. This fixes a critical bug introduced by the `CVE-2025-15661` patch which caused the request ID to be incorrectly interpreted as the status code.
    *   *Backported from upstream commit*: `4ed26f5740bdd409269ed9fb48a28bf8f565b681`

The submodule commit is updated to `090f23d1852a0b62e081bd12c4d05adc1c4af47a`, which resides in `Manishearth/libssh2` (branch `backport-cve-2026-55200`).

> [!NOTE]
> For upstream CI to pass, these commits will need to be made available in the main `libssh2/libssh2` repository, as the `.gitmodules` still points there. However, this is fully ready for packaging/release since `libssh2-sys` bundles the C source code on `cargo publish`. We have temporarily updated `.gitmodules` to point to the fork to ensure CI runs green on this PR in the meantime.

### Changes:
*   Update `libssh2` submodule to patched `1.11.1` (`090f23d1`).
*   Bump `libssh2-sys` version to `0.3.2`.
*   Bump `ssh2` version to `0.9.6` and update its dependency on `libssh2-sys` to `0.3.2`.
*   Temporarily point submodule URL to `Manishearth/libssh2` fork to make CI green.