### PR TITLE
ssh2: re-export libssh2-sys in the public api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,12 +216,14 @@
 #![cfg_attr(test, deny(warnings))]
 
 extern crate libc;
-extern crate libssh2_sys as raw;
+pub extern crate libssh2_sys;
 #[macro_use]
 extern crate bitflags;
 extern crate parking_lot;
 
 use std::ffi::CStr;
+
+use libssh2_sys as raw;
 
 pub use agent::{Agent, PublicKey};
 pub use channel::{Channel, ExitSignal, ReadWindow, Stream, WriteWindow};


### PR DESCRIPTION
This will give consumers of ssh2 access to the constants defined in libssh2-sys, without having to add libssh2-sys as a direct dependency.

Closes #364 
